### PR TITLE
Fix OpenWrt cross-compilation issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ endif
 
 ###########################################################################
 
-CFLAGS += -std=c99 -pedantic -D_XOPEN_SOURCE=700
-CFLAGS += -Wall -Wextra -Wno-unused-parameter $(DEBUG) -fPIC -I. $(LUA_CFLAGS)
-LDFLAGS += -shared
+LIB_CFLAGS += -std=c99 -pedantic -D_XOPEN_SOURCE=700
+LIB_CFLAGS += -Wall -Wextra -Wno-unused-parameter $(DEBUG) -fPIC -I. $(LUA_CFLAGS)
+LIB_LDFLAGS += -shared
 
 ###########################################################################
 
@@ -38,7 +38,7 @@ install:
 ###########################################################################
 
 $(LIB): $(C_PERIPHERY_LIB) $(SRCS)
-	$(CC) $(CFLAGS) $(LDFLAGS) $(SRCS) $(C_PERIPHERY_LIB) -o $@
+	$(CC) $(CFLAGS) $(LIB_CFLAGS) $(LDFLAGS) $(LIB_LDFLAGS) $(SRCS) $(C_PERIPHERY_LIB) -o $@
 
 $(C_PERIPHERY_LIB): $(C_PERIPHERY)/Makefile
 	cd $(C_PERIPHERY); $(MAKE)


### PR DESCRIPTION
Attempts for cross-compiling _lib-periphery_ with OpenWRT toolchain failed, because of invalid includes in `CFLAGS`:

```
$ export LUA_INCDIR=$TARGET_DIR/usr/include
$ git clone --recursive https://github.com/vsergeev/lua-periphery.git
$ cd lua-periphery/
$ make clean all
cd c-periphery && make clean
make[1]: Entering directory '/home/foo/lua-periphery/c-periphery'
rm -rf periphery.a obj tests/test_serial tests/test_i2c tests/test_mmio tests/test_spi tests/test_gpio
make[1]: Leaving directory '/home/foo/lua-periphery/c-periphery'
rm -rf periphery.so
cd c-periphery; make
make[1]: Entering directory '/home/foo/lua-periphery/c-periphery'
mkdir obj
mipsel-openwrt-linux-musl-gcc  -std=c99 -pedantic -D_XOPEN_SOURCE=700 -Wall -Wextra -Wno-unused-parameter  -fPIC -I. -I/home/foo/openwrt/staging_dir/target-mipsel_24kec+dsp_musl-1.1.14//usr/include -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -Wno-pointer-to-int-cast  -fPIC  -c src/gpio.c -o obj/gpio.o
mipsel-openwrt-linux-musl-gcc  -std=c99 -pedantic -D_XOPEN_SOURCE=700 -Wall -Wextra -Wno-unused-parameter  -fPIC -I. -I/home/foo/openwrt/staging_dir/target-mipsel_24kec+dsp_musl-1.1.14//usr/include -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -Wno-pointer-to-int-cast  -fPIC  -c src/spi.c -o obj/spi.o
mipsel-openwrt-linux-musl-gcc  -std=c99 -pedantic -D_XOPEN_SOURCE=700 -Wall -Wextra -Wno-unused-parameter  -fPIC -I. -I/home/foo/openwrt/staging_dir/target-mipsel_24kec+dsp_musl-1.1.14//usr/include -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -Wno-pointer-to-int-cast  -fPIC  -c src/i2c.c -o obj/i2c.o
mipsel-openwrt-linux-musl-gcc  -std=c99 -pedantic -D_XOPEN_SOURCE=700 -Wall -Wextra -Wno-unused-parameter  -fPIC -I. -I/home/foo/openwrt/staging_dir/target-mipsel_24kec+dsp_musl-1.1.14//usr/include -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -Wno-pointer-to-int-cast  -fPIC  -c src/mmio.c -o obj/mmio.o
mipsel-openwrt-linux-musl-gcc  -std=c99 -pedantic -D_XOPEN_SOURCE=700 -Wall -Wextra -Wno-unused-parameter  -fPIC -I. -I/home/foo/openwrt/staging_dir/target-mipsel_24kec+dsp_musl-1.1.14//usr/include -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -Wno-pointer-to-int-cast  -fPIC  -c src/serial.c -o obj/serial.o
src/serial.c: In function 'serial_open_advanced':
src/serial.c:182:37: error: 'CRTSCTS' undeclared (first use in this function)
         termios_settings.c_cflag |= CRTSCTS;
                                     ^
src/serial.c:182:37: note: each undeclared identifier is reported only once for each function it appears in
src/serial.c: In function 'serial_get_rtscts':
src/serial.c:378:36: error: 'CRTSCTS' undeclared (first use in this function)
     if (termios_settings.c_cflag & CRTSCTS)
                                    ^
src/serial.c: In function 'serial_set_rtscts':
src/serial.c:488:34: error: 'CRTSCTS' undeclared (first use in this function)
     termios_settings.c_cflag &= ~CRTSCTS;
                                  ^
src/serial.c: In function 'serial_tostring':
src/serial.c:536:36: error: 'CRTSCTS' undeclared (first use in this function)
     if (termios_settings.c_cflag & CRTSCTS)
                                    ^
Makefile:45: recipe for target 'obj/serial.o' failed
make[1]: *** [obj/serial.o] Error 1
make[1]: Leaving directory '/home/foo/lua-periphery/c-periphery'
Makefile:44: recipe for target 'c-periphery/periphery.a' failed
make: *** [c-periphery/periphery.a] Error 2
```

But manually compiling _c-periphery_ works without errors:

``` bash
$ cd c-periphery/
$ make clean all
rm -rf periphery.a obj tests/test_serial tests/test_i2c tests/test_mmio tests/test_spi tests/test_gpio
mkdir obj
mipsel-openwrt-linux-musl-gcc  -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -Wno-pointer-to-int-cast  -fPIC  -c src/gpio.c -o obj/gpio.o
mipsel-openwrt-linux-musl-gcc  -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -Wno-pointer-to-int-cast  -fPIC  -c src/spi.c -o obj/spi.o
mipsel-openwrt-linux-musl-gcc  -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -Wno-pointer-to-int-cast  -fPIC  -c src/i2c.c -o obj/i2c.o
mipsel-openwrt-linux-musl-gcc  -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -Wno-pointer-to-int-cast  -fPIC  -c src/mmio.c -o obj/mmio.o
mipsel-openwrt-linux-musl-gcc  -std=gnu99 -pedantic -Wall -Wextra -Wno-unused-parameter -Wno-pointer-to-int-cast  -fPIC  -c src/serial.c -o obj/serial.o
ar rcs periphery.a obj/gpio.o obj/spi.o obj/i2c.o obj/mmio.o obj/serial.o
```
