### PR TITLE
Fix for multiple I2C messages. Pop message table from LUA stack

### DIFF
--- a/src/lua_i2c.c
+++ b/src/lua_i2c.c
@@ -254,6 +254,7 @@ static int lua_i2c_transfer(lua_State *L) {
                 lua_pushunsigned(L, i2c_msgs[i].buf[j]);
                 lua_settable(L, -3);
             }
+            lua_pop(L, 1);
         }
     }
 


### PR DESCRIPTION
Following error during execution of i2c:transfer()
> lua: attempt to index a nil value

occurs when try to transfer more messages at once.

My code to reproduce error:
```lua
local msgs = { { 0x00 }, {0x00, 0x00, flags = I2C.I2C_M_RD},
               { 0x01 }, {0x00,       flags = I2C.I2C_M_RD},
               { 0x02 }, {0x00, 0x00, flags = I2C.I2C_M_RD},
               { 0x03 }, {0x00, 0x00, flags = I2C.I2C_M_RD},
             }
i2c:transfer(i2c_addr, msgs)

print(string.format("[0x00] Temperature...: 0x%02x%02x", msgs[2][1], msgs[2][2]))
print(string.format("[0x01] Configuration.: 0x%02x"    , msgs[4][1]))
print(string.format("[0x03] Thys..........: 0x%02x%02x", msgs[6][1], msgs[6][2]))
print(string.format("[0x04] Tos...........: 0x%02x%02x", msgs[8][1], msgs[8][2]))
```
